### PR TITLE
Take nonce from access token into account

### DIFF
--- a/Modules/Features/BITOpenID/Sources/BITOpenID/Domain/Models/Issuance/AccessToken.swift
+++ b/Modules/Features/BITOpenID/Sources/BITOpenID/Domain/Models/Issuance/AccessToken.swift
@@ -20,6 +20,7 @@ public struct AccessToken: Codable, Equatable {
     accessToken = try container.decode(String.self, forKey: .accessToken)
     expiresIn = try container.decodeIfPresent(Int.self, forKey: .expiresIn)
     refreshToken = try container.decodeIfPresent(String.self, forKey: .refreshToken)
+    nonce = try container.decodeIfPresent(String.self, forKey: .nonce)
 
     let rawType = try container.decode(String.self, forKey: .tokenType)
     guard let type = TokenType(rawValue: rawType.lowercased()) else {
@@ -41,11 +42,13 @@ public struct AccessToken: Codable, Equatable {
     case tokenType = "token_type"
     case expiresIn = "expires_in"
     case refreshToken = "refresh_token"
+    case nonce = "c_nonce"
   }
 
   let accessToken: String
   let tokenType: TokenType
   let expiresIn: Int?
   let refreshToken: String?
+  let nonce: String?
 
 }

--- a/Modules/Features/BITOpenID/Sources/BITOpenID/Domain/UseCases/FetchAnyVerifiableCredentialUseCase.swift
+++ b/Modules/Features/BITOpenID/Sources/BITOpenID/Domain/UseCases/FetchAnyVerifiableCredentialUseCase.swift
@@ -41,7 +41,11 @@ struct FetchAnyVerifiableCredentialUseCase: FetchAnyVerifiableCredentialUseCaseP
     let issuerUrl = try getIssuerUrl(from: offer)
     let configuration = try await repository.fetchOpenIdConfiguration(from: issuerUrl)
     let accessToken = try await fetchAccessToken(tokenEndpoint: configuration.tokenEndpoint, credentialOffer: offer)
-    let nonce = try await fetchNonceIfNeeded(from: metadataWrapper, holderBindingContext: holderBindingContext)
+    let nonce = if let nonceString = accessToken.nonce {
+      Nonce(cNonce: nonceString)
+    } else {
+      try await fetchNonceIfNeeded(from: metadataWrapper, holderBindingContext: holderBindingContext)
+    }
 
     let context = FetchCredentialContext(
       credentialConfigurationId: metadataWrapper.credentialConfigurationId,


### PR DESCRIPTION
Hello, I got the [generic issuer](https://github.com/swiyu-admin-ch/swiyu-issuer) running and the credentials generated cannot be imported into the app rightaway.

It looks like the default (recommended?) [issuer metadata](https://github.com/swiyu-admin-ch/swiyu-issuer/blob/64e641571e764916aaf6e0aac04f9b4e27e4c12f/sample.compose.yml#L75-L77) doesn't include a `nonce_endpoint`.

The nonce is [returned along with access_token instead](https://github.com/swiyu-admin-ch/swiyu-issuer/blob/64e641571e764916aaf6e0aac04f9b4e27e4c12f/issuance.md?plain=1#L289).
The current implementation doesn't take that into account and sends a request without a nonce, causing a NullPointerException around [here](https://github.com/swiyu-admin-ch/swiyu-issuer/blob/64e641571e764916aaf6e0aac04f9b4e27e4c12f/issuer-service/src/main/java/ch/admin/bj/swiyu/issuer/domain/openid/credentialrequest/holderbinding/ProofJwt.java#L163).

This PR takes the `c_nonce` from the access token and pass it along.